### PR TITLE
feat: add `use_worker_client` option to the Scaler backends

### DIFF
--- a/parfun/backend/scaler.py
+++ b/parfun/backend/scaler.py
@@ -9,6 +9,7 @@ try:
     from scaler import Client, SchedulerClusterCombo
     from scaler.client.future import ScalerFuture
     from scaler.client.object_reference import ObjectReference
+    from scaler.worker.agent.processor.processor import Processor
 except ImportError:
     raise ImportError("Scaler dependency missing. Use `pip install 'opengris-parfun[scaler]'` to install Scaler.")
 
@@ -23,9 +24,14 @@ class ScalerSession(BackendSession):
     # Additional constant scheduling overhead that cannot be accounted for when measuring the task execution duration.
     CONSTANT_SCHEDULING_OVERHEAD = 8_000_000  # 8ms
 
-    def __init__(self, scheduler_address: str, n_workers: int, client_kwargs: Dict):
+    def __init__(self, scheduler_address: str, n_workers: int, client_kwargs: Dict, use_worker_client: bool = False):
+        """
+        :param use_worker_client: if ``True`` and the session is created inside a Scaler worker, connects to the
+            scheduler the worker is currently connected to, instead of using ``scheduler_address``.
+        """
+
         self._concurrent_task_guard = BoundedSemaphore(n_workers)
-        self._client = Client(address=scheduler_address, profiling=True, **client_kwargs)
+        self._client = self.__get_client_instance(scheduler_address, client_kwargs, use_worker_client)
 
     def __enter__(self) -> "ScalerSession":
         return self
@@ -78,6 +84,29 @@ class ScalerSession(BackendSession):
 
         return future
 
+    @staticmethod
+    def __get_client_instance(scheduler_address: str, client_kwargs: Dict, use_worker_client: bool) -> Client:
+        """
+        Instantiates the Scaler client to submit the session's tasks with.
+
+        When ``use_worker_client`` is set and we are currently running inside a Scaler worker, lets Scaler resolve the
+        scheduler's address from the running worker instead of reusing the (possibly unreachable) address from the
+        parent task.
+        """
+
+        is_inside_worker = Processor.get_current_processor() is not None
+
+        if use_worker_client and is_inside_worker:
+            worker_client_kwargs = {
+                kwarg: value
+                for kwarg, value in client_kwargs.items()
+                if kwarg not in {"address", "object_storage_address"}
+            }
+
+            return Client(address=None, profiling=True, **worker_client_kwargs)
+
+        return Client(address=scheduler_address, profiling=True, **client_kwargs)
+
 
 class ScalerClientPool:
     def __init__(self, scheduler_address: str, client_kwargs: Dict, max_unused_clients: int = 1):
@@ -126,11 +155,22 @@ class ScalerRemoteBackend(BackendEngine):
         scheduler_address: str,
         n_workers: int = psutil.cpu_count(logical=False) - 1,
         allows_nested_tasks: bool = True,
+        use_worker_client: bool = False,
         **client_kwargs,
     ):
+        """
+        :param use_worker_client: if ``True``, nested tasks connect to the scheduler their worker is currently
+            connected to, instead of reusing the address and the network settings of the process that submitted the
+            parent task.
+
+            Required when the workers cannot reach the scheduler at the same address as the submitting process
+            (e.g. NAT-ed, Docker or Kubernetes deployments).
+        """
+
         self._scheduler_address = scheduler_address
         self._n_workers = n_workers
         self._allows_nested_tasks = allows_nested_tasks
+        self._use_worker_client = use_worker_client
         self._client_kwargs = client_kwargs
 
     def __getstate__(self) -> dict:
@@ -138,6 +178,7 @@ class ScalerRemoteBackend(BackendEngine):
             "scheduler_address": self._scheduler_address,
             "n_workers": self._n_workers,
             "allows_nested_tasks": self._allows_nested_tasks,
+            "use_worker_client": self._use_worker_client,
             "client_kwargs": self._client_kwargs,
         }
 
@@ -145,10 +186,11 @@ class ScalerRemoteBackend(BackendEngine):
         self._scheduler_address = state["scheduler_address"]
         self._n_workers = state["n_workers"]
         self._allows_nested_tasks = state["allows_nested_tasks"]
+        self._use_worker_client = state["use_worker_client"]
         self._client_kwargs = state["client_kwargs"]
 
     def session(self) -> ScalerSession:
-        return ScalerSession(self._scheduler_address, self._n_workers, self._client_kwargs)
+        return ScalerSession(self._scheduler_address, self._n_workers, self._client_kwargs, self._use_worker_client)
 
     def get_scheduler_address(self) -> str:
         return self._scheduler_address
@@ -172,6 +214,7 @@ class ScalerLocalBackend(ScalerRemoteBackend):
         n_workers: int = psutil.cpu_count(logical=False) - 1,
         per_worker_task_queue_size: int = 1000,
         allows_nested_tasks: bool = True,
+        use_worker_client: bool = False,
         logging_paths: Tuple[str, ...] = ("/dev/stdout",),
         logging_level: str = "INFO",
         logging_config_file: Optional[str] = None,
@@ -180,6 +223,7 @@ class ScalerLocalBackend(ScalerRemoteBackend):
         """
         :param scheduler_address the ``tcp://host:port`` tuple to use as a cluster address. If ``None``, listen to the
         local host on an available TCP port.
+        :param use_worker_client: see :class:`ScalerRemoteBackend`.
         """
 
         client_kwargs = self.__get_constructor_arg_names(Client)
@@ -199,6 +243,7 @@ class ScalerLocalBackend(ScalerRemoteBackend):
         super().__init__(
             scheduler_address=scheduler_address,
             allows_nested_tasks=allows_nested_tasks,
+            use_worker_client=use_worker_client,
             n_workers=n_workers,
             **{kwarg: value for kwarg, value in kwargs.items() if kwarg in client_kwargs},
         )

--- a/tests/backend/test_scaler.py
+++ b/tests/backend/test_scaler.py
@@ -10,7 +10,17 @@ except ImportError:
     scaler_installed = False
 
 from tests.backend.mixins import BackendEngineTestCase
-from tests.backend.utility import warmup_workers
+from tests.backend.utility import no_op_task, warmup_workers
+
+# A valid but unbound address. Any client trying to connect to it will fail to submit tasks.
+UNREACHABLE_SCHEDULER_ADDRESS = "tcp://127.0.0.1:1"
+
+
+def nested_session_task(backend: BackendEngine) -> None:
+    """Submits a nested task from inside a worker, using the deserialized backend instance."""
+
+    with backend.session() as session:
+        return session.submit(no_op_task).result()
 
 
 @unittest.skipUnless(scaler_installed, "Scaler backend not installed")
@@ -34,6 +44,37 @@ class TestScalerBackend(unittest.TestCase, BackendEngineTestCase):
     def test_is_backend_scaler_remote(self):
         # ScalerLocalBackend is a special case of ScalerRemoteBackend, so no need to test ScalerRemoteBackend
         self.assertIsInstance(self._backend, (ScalerRemoteBackend, ScalerLocalBackend))
+
+    def test_use_worker_client_ignores_parent_scheduler_address(self):
+        """
+        Nested tasks should connect to their worker's scheduler instead of the parent's address.
+
+        The backend instance the workers receive advertises an unreachable scheduler address. Nested tasks will only
+        succeed if they ignore it in favor of their worker's scheduler.
+        """
+
+        nested_backend = ScalerRemoteBackend(
+            scheduler_address=UNREACHABLE_SCHEDULER_ADDRESS, n_workers=self.n_workers(), use_worker_client=True
+        )
+
+        with self.backend().session() as session:
+            self.assertIsNone(session.submit(nested_session_task, nested_backend).result())
+
+    def test_use_worker_client_disabled_uses_parent_scheduler_address(self):
+        """With `use_worker_client=False`, the parent's unreachable address should be used, and thus fail."""
+
+        CLIENT_TIMEOUT_SECONDS = 3
+
+        nested_backend = ScalerRemoteBackend(
+            scheduler_address=UNREACHABLE_SCHEDULER_ADDRESS,
+            n_workers=self.n_workers(),
+            use_worker_client=False,
+            timeout_seconds=CLIENT_TIMEOUT_SECONDS,
+        )
+
+        with self.backend().session() as session:
+            with self.assertRaises(Exception):
+                session.submit(nested_session_task, nested_backend).result()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #70 by allowing Scaler backend instances to use the worker's scheduler and OSS config for nested tasks.